### PR TITLE
Adding pragma to work around GCC 'bug'.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,9 @@
 # Release Notes&mdash;NJOY21
 Given here are some release notes for NJOY21. Each release is made through a formal [Pull Request](https://github.com/njoy/NJOY21/pulls) made on GitHub. There are links in this document that point to each of those Pull Requests, where you can see in great details the changes that were made. Often the Pull Requests are made in response to an [issue](https://github.com/njoy/NJOY21/issues). In such cases, links to those issues are also given.
 
+## pNJOY21 1.1.1](https://github.com/njoy/NJOY21/pull/107)
+This update fixes an issue where GCC would complain about a "maybe" uninitialized variable in [lipservice](https://github.com/njoy/lipservice). This only happens when compiled in release mode with GCC. Using the clang/LLVM compiler does not invoke this warning/error.
+
 ## [NJOY21 1.1.0](https://github.com/njoy/NJOY21/pull/104)
 This update moves the C++ standard to C++17; thus, a c++17-compliant compiler is needed to build NJOY21. Fortunately, C++17-compliant compilers have been available for several years.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,8 +1,10 @@
 # Release Notes&mdash;NJOY21
 Given here are some release notes for NJOY21. Each release is made through a formal [Pull Request](https://github.com/njoy/NJOY21/pulls) made on GitHub. There are links in this document that point to each of those Pull Requests, where you can see in great details the changes that were made. Often the Pull Requests are made in response to an [issue](https://github.com/njoy/NJOY21/issues). In such cases, links to those issues are also given.
 
-## pNJOY21 1.1.1](https://github.com/njoy/NJOY21/pull/107)
+## [NJOY21 1.1.1](https://github.com/njoy/NJOY21/pull/107)
 This update fixes an issue where GCC would complain about a "maybe" uninitialized variable in [lipservice](https://github.com/njoy/lipservice). This only happens when compiled in release mode with GCC. Using the clang/LLVM compiler does not invoke this warning/error.
+
+This update address issue #106.
 
 ## [NJOY21 1.1.0](https://github.com/njoy/NJOY21/pull/104)
 This update moves the C++ standard to C++17; thus, a c++17-compliant compiler is needed to build NJOY21. Fortunately, C++17-compliant compilers have been available for several years.

--- a/src/njoy21.hpp
+++ b/src/njoy21.hpp
@@ -17,7 +17,11 @@
 #include "dimwits.hpp"
 #include "Log.hpp"
 #include "utility.hpp"
-#include "lipservice.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+  #include "lipservice.hpp"
+#pragma GCC diagnostic pop
 
 #include "njoy_c.h"
 

--- a/src/njoy21/Version.hpp
+++ b/src/njoy21/Version.hpp
@@ -4,7 +4,7 @@ public:
   // Change whenever new capability is implemented
   static constexpr int minorVersion{1};
   // Change whenever merge to master branch is done
-  static constexpr int patchVersion{0};
+  static constexpr int patchVersion{1};
 
   static std::string version(){
     return std::to_string( majorVersion ) + "." +


### PR DESCRIPTION
This update fixes an issue where GCC would complain about a "maybe" uninitialized variable in [lipservice](https://github.com/njoy/lipservice). This only happens when compiled in release mode with GCC. Using the clang/LLVM compiler does not invoke this warning/error.

This shoud fix #106.