### PR TITLE
Removing njoy21 library creation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,21 +47,6 @@ endif()
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/src/njoy21/Signature.hpp.in"
                 "${CMAKE_CURRENT_BINARY_DIR}/src/njoy21/Signature.hpp" @ONLY )
 
-add_library( njoy21 src/main.cpp )
-target_include_directories( njoy21 
-    PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/src/
-           src/
-    )
-target_link_libraries( njoy21
-    PUBLIC ENDFtk
-    PUBLIC RECONR
-    PUBLIC tclap-adapter
-    PUBLIC njoy_c_bindings
-    PUBLIC lipservice
-    PUBLIC dimwits
-    PUBLIC utility
-    )
-
 
 #######################################################################
 # Top-level Only
@@ -71,11 +56,25 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 
     # add NJOY21 executable
     message( STATUS "Adding executable" )
-    add_executable( NJOY21_executable src/main.cpp )
-    set_target_properties( NJOY21_executable
+    add_executable( njoy21 src/main.cpp )
+    target_include_directories( njoy21 
+        PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/src/
+              src/
+        )
+
+    set_target_properties( njoy21
                            PROPERTIES OUTPUT_NAME njoy21
                            )
-    target_link_libraries( NJOY21_executable PUBLIC njoy21 )
+
+    target_link_libraries( njoy21
+        PUBLIC ENDFtk
+        PUBLIC RECONR
+        PUBLIC tclap-adapter
+        PUBLIC njoy_c_bindings
+        PUBLIC lipservice
+        PUBLIC dimwits
+        PUBLIC utility
+        )
 
     # unit testing
     if( unit_tests )

--- a/src/njoy21/CommandLine/test/CMakeLists.txt
+++ b/src/njoy21/CommandLine/test/CMakeLists.txt
@@ -10,5 +10,13 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${njoy21_appended_flags} )
-target_link_libraries( njoy21.CommandLine.test PUBLIC njoy21 ) 
+target_link_libraries( njoy21.CommandLine.test
+    PUBLIC ENDFtk
+    PUBLIC RECONR
+    PUBLIC tclap-adapter
+    PUBLIC njoy_c_bindings
+    PUBLIC lipservice
+    PUBLIC dimwits
+    PUBLIC utility
+    )
 add_test( NAME njoy21.CommandLine COMMAND njoy21.CommandLine.test )

--- a/src/njoy21/Driver/test/CMakeLists.txt
+++ b/src/njoy21/Driver/test/CMakeLists.txt
@@ -10,9 +10,17 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${njoy21_appended_flags} )
-target_link_libraries( njoy21.Driver.test PUBLIC njoy21 ) 
 file( GLOB resources "resources/*" )
 foreach( resource ${resources})
     file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
 endforeach()
+target_link_libraries( njoy21.Driver.test
+    PUBLIC ENDFtk
+    PUBLIC RECONR
+    PUBLIC tclap-adapter
+    PUBLIC njoy_c_bindings
+    PUBLIC lipservice
+    PUBLIC dimwits
+    PUBLIC utility
+    )
 add_test( NAME njoy21.Driver COMMAND njoy21.Driver.test )

--- a/src/njoy21/io/Manager/test/CMakeLists.txt
+++ b/src/njoy21/io/Manager/test/CMakeLists.txt
@@ -10,9 +10,17 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${njoy21_appended_flags} )
-target_link_libraries( njoy21.io.Manager.test PUBLIC njoy21 ) 
 file( GLOB resources "resources/*" )
 foreach( resource ${resources})
     file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
 endforeach()
+target_link_libraries( njoy21.io.Manager.test
+    PUBLIC ENDFtk
+    PUBLIC RECONR
+    PUBLIC tclap-adapter
+    PUBLIC njoy_c_bindings
+    PUBLIC lipservice
+    PUBLIC dimwits
+    PUBLIC utility
+    )
 add_test( NAME njoy21.io.Manager COMMAND njoy21.io.Manager.test )

--- a/src/njoy21/legacy/Sequence/test/CMakeLists.txt
+++ b/src/njoy21/legacy/Sequence/test/CMakeLists.txt
@@ -10,5 +10,13 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${njoy21_appended_flags} )
-target_link_libraries( njoy21.legacy.Sequence.test PUBLIC njoy21 ) 
+target_link_libraries( njoy21.legacy.Sequence.test
+    PUBLIC ENDFtk
+    PUBLIC RECONR
+    PUBLIC tclap-adapter
+    PUBLIC njoy_c_bindings
+    PUBLIC lipservice
+    PUBLIC dimwits
+    PUBLIC utility
+    )
 add_test( NAME njoy21.legacy.Sequence COMMAND njoy21.legacy.Sequence.test )

--- a/src/njoy21/modern/Sequence/test/CMakeLists.txt
+++ b/src/njoy21/modern/Sequence/test/CMakeLists.txt
@@ -10,5 +10,13 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${njoy21_appended_flags} )
-target_link_libraries( njoy21.modern.Sequence.test PUBLIC njoy21 ) 
+target_link_libraries( njoy21.modern.Sequence.test
+    PUBLIC ENDFtk
+    PUBLIC RECONR
+    PUBLIC tclap-adapter
+    PUBLIC njoy_c_bindings
+    PUBLIC lipservice
+    PUBLIC dimwits
+    PUBLIC utility
+    )
 add_test( NAME njoy21.modern.Sequence COMMAND njoy21.modern.Sequence.test )


### PR DESCRIPTION
This is an attempt to remove the extra step of creating an NJOY21 library, which doesn't really make sense.